### PR TITLE
Use logging framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,9 @@ _testmain.go
 *.test
 *.prof
 
+# Intellij Idea
+.idea
+
 .goxc.local.json
+
+subify

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You've developed a cool feature or fixed a bug ?
 4. Vendoring
 5. Doc on default configuration (for example to change the default language for all downloads)
 6. Use OpenSubtitles API and/or Addic7ed (better quality of translations, but no API)
+7. Localization/Internationalization
 
 ## License
 Subify is released under the Apache 2.0 license. See LICENSE.txt

--- a/cmd/dl.go
+++ b/cmd/dl.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/vincentdaniel/subify/common/utils"
-	"github.com/vincentdaniel/subify/subtitles"
+	"github.com/matcornic/subify/common/utils"
+	"github.com/matcornic/subify/subtitles"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/dl.go
+++ b/cmd/dl.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/matcornic/subify/common/utils"
 	"github.com/matcornic/subify/subtitles"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"strings"
 	logger "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
 )
 
 var language string
@@ -23,7 +24,7 @@ Give the path of your video as first parameter and let's go !`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Assertions
 		utils.VerbosePrintln(logger.INFO,
-			"Downloading command called with following parameters : " + strings.Join(args, " "))
+			"Downloading command called with following parameters : "+strings.Join(args, " "))
 		if len(args) != 1 {
 			utils.Exit("Video file needed. See usage : 'subify help' or 'subify dl --help'")
 		}
@@ -41,7 +42,7 @@ func init() {
 	dlCmd.Flags().StringVarP(&language, "language", "l", "en", "Language of the subtitle")
 	viper.BindPFlag("language", dlCmd.Flags().Lookup("language"))
 	dlCmd.Flags().BoolVarP(&openVideo, "open", "o", false,
-		"Once the subtitle is donwloaded, open the video with your default video player" +
-		` (OSX: "open", Windows: "start", Linux/Other: "xdg-open")`)
+		"Once the subtitle is donwloaded, open the video with your default video player"+
+			` (OSX: "open", Windows: "start", Linux/Other: "xdg-open")`)
 	RootCmd.AddCommand(dlCmd)
 }

--- a/cmd/dl.go
+++ b/cmd/dl.go
@@ -1,14 +1,13 @@
 package cmd
 
 import (
-	"fmt"
-	"github.com/matcornic/subify/common/config"
-	"github.com/matcornic/subify/common/utils"
-	"github.com/matcornic/subify/subtitles"
+	"github.com/vincentdaniel/subify/common/utils"
+	"github.com/vincentdaniel/subify/subtitles"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"strings"
+	logger "github.com/spf13/jwalterweatherman"
 )
 
 var language string
@@ -23,9 +22,8 @@ var dlCmd = &cobra.Command{
 Give the path of your video as first parameter and let's go !`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Assertions
-		if config.Verbose {
-			fmt.Println("Downloading command called with following parameters : " + strings.Join(args, " "))
-		}
+		utils.VerbosePrintln(logger.INFO,
+			"Downloading command called with following parameters : " + strings.Join(args, " "))
 		if len(args) != 1 {
 			utils.Exit("Video file needed. See usage : 'subify help' or 'subify dl --help'")
 		}
@@ -42,6 +40,8 @@ Give the path of your video as first parameter and let's go !`,
 func init() {
 	dlCmd.Flags().StringVarP(&language, "language", "l", "en", "Language of the subtitle")
 	viper.BindPFlag("language", dlCmd.Flags().Lookup("language"))
-	dlCmd.Flags().BoolVarP(&openVideo, "open", "o", false, "Once the subtitle is donwloaded, open the video with your default video player (OSX: \"open\", Windows: \"start\", Linux/Other: \"xdg-open\")")
+	dlCmd.Flags().BoolVarP(&openVideo, "open", "o", false,
+		"Once the subtitle is donwloaded, open the video with your default video player" +
+		` (OSX: "open", Windows: "start", Linux/Other: "xdg-open")`)
 	RootCmd.AddCommand(dlCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-	"github.com/matcornic/subify/common/config"
+	"github.com/vincentdaniel/subify/common/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
+	logger "github.com/spf13/jwalterweatherman"
+	"github.com/vincentdaniel/subify/common/utils"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -13,26 +13,34 @@ var RootCmd = &cobra.Command{
 	Use:   "subify",
 	Short: "Tool to handle subtitles for your best TV Shows and movies",
 	Long: `Tool to handle subtitles for your best TV Shows and movies
-http://github.com/matcornic/subify`,
+http://github.com/vincentdaniel/subify`,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(-1)
+		utils.ExitPrintError(err, "An error occurred while running subify")
 	}
 }
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	// Default configuration can be overrided
-	RootCmd.PersistentFlags().StringVar(&config.ConfigFile, "config", "", "Config file (default is $HOME/.subify.json). Build a file like this to change default behaviour")
-	RootCmd.PersistentFlags().BoolVarP(&config.Verbose, "verbose", "v", false, "Print more information while executing")
-	RootCmd.PersistentFlags().BoolVarP(&config.Dev, "dev", "", false, "Instanciate development sandbox instead of production variables")
+	// Default configuration can be overridden
+	RootCmd.PersistentFlags().StringVar(&config.ConfigFile, "config", "",
+		"Config file (default is $HOME/.subify.json). Edit to change default behaviour")
+	RootCmd.PersistentFlags().BoolVarP(&config.Verbose, "verbose", "v", false,
+		"Print more information while executing")
+	RootCmd.PersistentFlags().BoolVarP(&config.Dev, "dev", "", false,
+		"Instanciate development sandbox instead of production variables")
 
 }
+
+
+const (
+	SubifyConfigPath = "$HOME"
+	SubifyConfigFile = ".subify"
+)
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
@@ -40,14 +48,17 @@ func initConfig() {
 		viper.SetConfigFile(config.ConfigFile)
 	}
 
-	viper.SetConfigName(".subify") // name of config file (without extension)
-	viper.AddConfigPath("$HOME")   // adding home directory as first search path
+	viper.SetConfigName(SubifyConfigFile) // name of config file (without extension)
+	viper.AddConfigPath(SubifyConfigPath)   // adding home directory as first search path
 	viper.AutomaticEnv()           // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
+	err := viper.ReadInConfig()
+	if err == nil {
 		if config.Verbose {
-			fmt.Println("Using config file:", viper.ConfigFileUsed())
+			logger.INFO.Println("Using config file:", viper.ConfigFileUsed())
 		}
+	} else {
+		logger.WARN.Println("Could not read config file (", viper.ConfigFileUsed(), "): ", err)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,9 +55,7 @@ func initConfig() {
 	// If a config file is found, read it in.
 	err := viper.ReadInConfig()
 	if err == nil {
-		if config.Verbose {
-			logger.INFO.Println("Using config file:", viper.ConfigFileUsed())
-		}
+		utils.VerbosePrintln(logger.INFO, "Using config file:" + viper.ConfigFileUsed())
 	} else {
 		logger.WARN.Println("Could not read config file (", viper.ConfigFileUsed(), "): ", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"github.com/matcornic/subify/common/config"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	logger "github.com/spf13/jwalterweatherman"
 	"github.com/matcornic/subify/common/utils"
+	"github.com/spf13/cobra"
+	logger "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -36,10 +36,9 @@ func init() {
 
 }
 
-
 const (
-	SubifyConfigPath = "$HOME"
-	SubifyConfigFile = ".subify"
+	subifyConfigPath = "$HOME"
+	subifyConfigFile = ".subify"
 )
 
 // initConfig reads in config file and ENV variables if set.
@@ -48,14 +47,14 @@ func initConfig() {
 		viper.SetConfigFile(config.ConfigFile)
 	}
 
-	viper.SetConfigName(SubifyConfigFile) // name of config file (without extension)
-	viper.AddConfigPath(SubifyConfigPath)   // adding home directory as first search path
-	viper.AutomaticEnv()           // read in environment variables that match
+	viper.SetConfigName(subifyConfigFile) // name of config file (without extension)
+	viper.AddConfigPath(subifyConfigPath) // adding home directory as first search path
+	viper.AutomaticEnv()                  // read in environment variables that match
 
 	// If a config file is found, read it in.
 	err := viper.ReadInConfig()
 	if err == nil {
-		utils.VerbosePrintln(logger.INFO, "Using config file:" + viper.ConfigFileUsed())
+		utils.VerbosePrintln(logger.INFO, "Using config file:"+viper.ConfigFileUsed())
 	} else {
 		logger.WARN.Println("Could not read config file (", viper.ConfigFileUsed(), "): ", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"github.com/vincentdaniel/subify/common/config"
+	"github.com/matcornic/subify/common/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	logger "github.com/spf13/jwalterweatherman"
-	"github.com/vincentdaniel/subify/common/utils"
+	"github.com/matcornic/subify/common/utils"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -13,7 +13,7 @@ var RootCmd = &cobra.Command{
 	Use:   "subify",
 	Short: "Tool to handle subtitles for your best TV Shows and movies",
 	Long: `Tool to handle subtitles for your best TV Shows and movies
-http://github.com/vincentdaniel/subify`,
+http://github.com/matcornic/subify`,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.

--- a/common/utils/logging.go
+++ b/common/utils/logging.go
@@ -1,20 +1,20 @@
 package utils
 
 import (
-	logger "github.com/spf13/jwalterweatherman"
-	"os"
 	"log"
+	"os"
+
+	logger "github.com/spf13/jwalterweatherman"
 )
 
-// TODO table with all error loggers
-// TODO table with all loggers
-
+// InitLoggingConf initializes the loggers used in the rest of the application
 func InitLoggingConf() {
 
 	errorLoggers := []*log.Logger{logger.ERROR, logger.CRITICAL, logger.FATAL}
 	allLoggers := append(errorLoggers, []*log.Logger{logger.INFO, logger.WARN}...)
 
-	// Log levels displayed to the user should not include debug/trace information, hence we remove the flags
+	// Log levels displayed to the user should not include debug/trace information
+	// hence we remove the flags
 	for _, log := range allLoggers {
 		log.SetFlags(0)
 	}
@@ -23,4 +23,3 @@ func InitLoggingConf() {
 		log.SetOutput(os.Stderr)
 	}
 }
-

--- a/common/utils/logging.go
+++ b/common/utils/logging.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	logger "github.com/spf13/jwalterweatherman"
+	"os"
+	"log"
+)
+
+// TODO table with all error loggers
+// TODO table with all loggers
+
+func InitLoggingConf() {
+
+	errorLoggers := []*log.Logger{logger.ERROR, logger.CRITICAL, logger.FATAL}
+	allLoggers := append(errorLoggers, []*log.Logger{logger.INFO, logger.WARN}...)
+
+	// Log levels displayed to the user should not include debug/trace information, hence we remove the flags
+	for _, log := range allLoggers {
+		log.SetFlags(0)
+	}
+
+	for _, log := range errorLoggers {
+		log.SetOutput(os.Stderr)
+	}
+}
+

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"crypto/md5"
 	"fmt"
-	"github.com/vincentdaniel/subify/common/config"
+	"github.com/matcornic/subify/common/config"
 	"os"
 	logger "github.com/spf13/jwalterweatherman"
 	"log"

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -3,8 +3,10 @@ package utils
 import (
 	"crypto/md5"
 	"fmt"
-	"github.com/matcornic/subify/common/config"
+	"github.com/vincentdaniel/subify/common/config"
 	"os"
+	logger "github.com/spf13/jwalterweatherman"
+	"log"
 )
 
 //GetHashOfVideo gets the hash used by SubDb to identify a video. Absolutely needed either to download or upload subtitles.
@@ -15,40 +17,28 @@ func GetHashOfVideo(filename string) string {
 	// Open Video
 	file, err := os.Open(filename)
 	if err != nil {
-		if config.Verbose {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		Exit("Can't open file " + filename)
+		ExitPrintError(err, "Can't open file ", filename)
 	}
 	defer file.Close()
 
 	// Get stats of file
 	fi, err := file.Stat()
 	if err != nil {
-		if config.Verbose {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		Exit("Can't open file " + filename)
+		ExitPrintError(err, "Can't get stats for file ", filename)
 	}
 
 	// Fill a buffer with first bytes of file
 	bufB := make([]byte, readsize)
 	_, err = file.Read(bufB)
 	if err != nil {
-		if config.Verbose {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		Exit("Can't read content of file " + filename)
+		ExitPrintError(err, "Can't read content of file ", filename)
 	}
 
 	//Fill a buffer with last bytes of file
 	bufE := make([]byte, readsize)
 	n, err := file.ReadAt(bufE, fi.Size()-int64(len(bufE)))
 	if err != nil {
-		if config.Verbose {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		Exit("Can't read content of file. File is probably too small : " + filename)
+		ExitPrintError(err, "Can't read content of file. File is probably too small: ", filename)
 	}
 	bufE = bufE[:n]
 
@@ -56,23 +46,39 @@ func GetHashOfVideo(filename string) string {
 	bufB = append(bufB, bufE...)
 	hash := fmt.Sprintf("%x", md5.Sum(bufB))
 
-	if config.Verbose {
-		fmt.Println("Hash of video is " + hash)
-	}
+	VerbosePrintln(logger.INFO, "Hash of video is " + hash)
 
 	return hash
 }
 
-// Exit func displays an error message on stderr and exit 1
-func Exit(format string, args ...interface{}) {
-	fmt.Fprintln(os.Stderr, fmt.Sprintf(format, args...))
-	if !config.Verbose {
-		fmt.Fprintln(os.Stderr, "Run subify with --verbose option to get more information about the error")
+func VerbosePrintln(logger *log.Logger, log string) {
+	if config.Verbose {
+		logger.Println(log)
 	}
-	os.Exit(1)
 }
 
-// Error func displays an error message on stderr
-func Error(format string, args ...interface{}) {
-	fmt.Fprintln(os.Stderr, fmt.Sprintf(format, args...))
+func Exit(format string, args ...interface{}) {
+	ExitVerbose("", format, args...)
+}
+
+/*
+ * Exit func displays an error message on stderr and exit 1
+ * Eventually prints more details about the error if verbose mode is enabled
+ */
+func ExitPrintError(err error, format string, args ...interface{}) {
+	ExitVerbose(fmt.Sprint(err), format, args...)
+}
+
+
+/*
+ * Exit func displays an error message on stderr and exit 1
+ * Eventually prints more details if any verbose details are given and verbose mode is enabled
+ */
+func ExitVerbose(verbose string, format string, args ...interface{}) {
+	if verbose != "" {
+		VerbosePrintln(logger.ERROR, verbose)
+	} else if !config.Verbose {
+		logger.ERROR.Println("Run subify with --verbose option to get more information about the error")
+	}
+	logger.FATAL.Printf(format)
 }

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -3,10 +3,11 @@ package utils
 import (
 	"crypto/md5"
 	"fmt"
-	"github.com/matcornic/subify/common/config"
-	"os"
-	logger "github.com/spf13/jwalterweatherman"
 	"log"
+	"os"
+
+	"github.com/matcornic/subify/common/config"
+	logger "github.com/spf13/jwalterweatherman"
 )
 
 //GetHashOfVideo gets the hash used by SubDb to identify a video. Absolutely needed either to download or upload subtitles.
@@ -46,34 +47,31 @@ func GetHashOfVideo(filename string) string {
 	bufB = append(bufB, bufE...)
 	hash := fmt.Sprintf("%x", md5.Sum(bufB))
 
-	VerbosePrintln(logger.INFO, "Hash of video is " + hash)
+	VerbosePrintln(logger.INFO, "Hash of video is "+hash)
 
 	return hash
 }
 
+// VerbosePrintln only prints log if verbose mode is enabled
 func VerbosePrintln(logger *log.Logger, log string) {
 	if config.Verbose && log != "" {
 		logger.Println(log)
 	}
 }
 
+// Exit exits the application and logs the given message
 func Exit(format string, args ...interface{}) {
 	ExitVerbose("", format, args...)
 }
 
-/*
- * Exit func displays an error message on stderr and exit 1
- * Eventually prints more details about the error if verbose mode is enabled
- */
+// ExitPrintError displays an error message on stderr and exit 1
+// Eventually prints more details about the error if verbose mode is enabled
 func ExitPrintError(err error, format string, args ...interface{}) {
 	ExitVerbose(fmt.Sprint(err), format, args...)
 }
 
-
-/*
- * Exit func displays an error message on stderr and exit 1
- * Eventually prints more details if any verbose details are given and verbose mode is enabled
- */
+// ExitVerbose displays an error message on stderr and exit 1
+// Eventually prints more details if any verbose details are given and verbose mode is enabled
 func ExitVerbose(verboseLog string, format string, args ...interface{}) {
 	VerbosePrintln(logger.ERROR, verboseLog)
 	if !config.Verbose {

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -52,7 +52,7 @@ func GetHashOfVideo(filename string) string {
 }
 
 func VerbosePrintln(logger *log.Logger, log string) {
-	if config.Verbose {
+	if config.Verbose && log != "" {
 		logger.Println(log)
 	}
 }
@@ -74,10 +74,9 @@ func ExitPrintError(err error, format string, args ...interface{}) {
  * Exit func displays an error message on stderr and exit 1
  * Eventually prints more details if any verbose details are given and verbose mode is enabled
  */
-func ExitVerbose(verbose string, format string, args ...interface{}) {
-	if verbose != "" {
-		VerbosePrintln(logger.ERROR, verbose)
-	} else if !config.Verbose {
+func ExitVerbose(verboseLog string, format string, args ...interface{}) {
+	VerbosePrintln(logger.ERROR, verboseLog)
+	if !config.Verbose {
 		logger.ERROR.Println("Run subify with --verbose option to get more information about the error")
 	}
 	logger.FATAL.Printf(format)

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/vincentdaniel/subify/cmd"
-	"github.com/vincentdaniel/subify/common/utils"
+	"github.com/matcornic/subify/cmd"
+	"github.com/matcornic/subify/common/utils"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,7 +1,11 @@
 package main
 
-import "github.com/matcornic/subify/cmd"
+import (
+	"github.com/vincentdaniel/subify/cmd"
+	"github.com/vincentdaniel/subify/common/utils"
+)
 
 func main() {
+	utils.InitLoggingConf()
 	cmd.Execute()
 }

--- a/subtitles/subdb/subdb.go
+++ b/subtitles/subdb/subdb.go
@@ -4,18 +4,18 @@ import (
 	"fmt"
 	"github.com/google/go-querystring/query"
 	"github.com/lafikl/fluent"
-	"github.com/matcornic/subify/common/config"
-	"github.com/matcornic/subify/common/utils"
+	"github.com/vincentdaniel/subify/common/config"
+	"github.com/vincentdaniel/subify/common/utils"
 	"github.com/spf13/viper"
 	"io/ioutil"
-	"os"
 	"time"
 )
 
-var (
-	userAgent = "SubDB/1.0 (Subify/0.1; http://github.com/matcornic/subify)"
+const (
+	userAgent = "SubDB/1.0 (Subify/0.1; http://github.com/vincentdaniel/subify)"
 	devURL    = "http://sandbox.thesubdb.com/"
 	prodURL   = "http://api.thesubdb.com/"
+	defaultLanguage = "en"
 )
 
 // SubDBOptions describes parameters to the SubDB API
@@ -49,7 +49,7 @@ func Subtitles(hash string) []byte {
 
 	// Build request
 	req := fluent.New()
-	req.Get(buildURL(hash, "en")).
+	req.Get(buildURL(hash, defaultLanguage)).
 		SetHeader("User-Agent", userAgent).
 		InitialInterval(time.Duration(time.Millisecond)).
 		Retry(3)
@@ -57,26 +57,19 @@ func Subtitles(hash string) []byte {
 	// Execute the request
 	res, err := req.Send()
 	if err != nil {
-		if config.Verbose {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		utils.Exit("Can't reach the SubDB Web API. Are you connected to the Internet ?")
+		utils.ExitPrintError(err, "Can't reach the SubDB Web API. Are you connected to the Internet ?")
 	}
 	if res.StatusCode != 200 {
-		if config.Verbose {
-			fmt.Println(fmt.Sprintf("Response : %v", res))
-		}
-		utils.Exit("Subtitle not found with SubDB Web API. Try with another language (See 'subify dl -h') You may contribute to the community by updating their database (see 'subify upload -h')")
+		utils.ExitVerbose(fmt.Sprintf("Response : %v", res),
+			`Subtitle not found with SubDB Web API. Try with another language (See 'subify dl -h').
+You may contribute to the community by updating their database (see 'subify upload -h')`)
 	}
 
 	// Extract the subtitles from the response
 	defer res.Body.Close()
 	content, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		if config.Verbose {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		utils.Exit("Can't read the content of the subtitle donwload from Subdb")
+		utils.ExitPrintError(err, "Can't read the content of the subtitles dowloaded from Subdb")
 	}
 
 	return content

--- a/subtitles/subdb/subdb.go
+++ b/subtitles/subdb/subdb.go
@@ -2,20 +2,21 @@ package subdb
 
 import (
 	"fmt"
+	"io/ioutil"
+	"time"
+
 	"github.com/google/go-querystring/query"
 	"github.com/lafikl/fluent"
 	"github.com/matcornic/subify/common/config"
 	"github.com/matcornic/subify/common/utils"
-	"github.com/spf13/viper"
-	"io/ioutil"
-	"time"
 	logger "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
 )
 
 const (
-	userAgent = "SubDB/1.0 (Subify/0.1; http://github.com/matcornic/subify)"
-	devURL    = "http://sandbox.thesubdb.com/"
-	prodURL   = "http://api.thesubdb.com/"
+	userAgent       = "SubDB/1.0 (Subify/0.1; http://github.com/matcornic/subify)"
+	devURL          = "http://sandbox.thesubdb.com/"
+	prodURL         = "http://api.thesubdb.com/"
 	defaultLanguage = "en"
 )
 
@@ -38,7 +39,7 @@ func buildURL(hash string, language string) string {
 	v, _ := query.Values(opt)
 
 	url := baseURL + "?" + v.Encode()
-	utils.VerbosePrintln(logger.INFO, "SubdbURL is : " + url)
+	utils.VerbosePrintln(logger.INFO, "SubdbURL is : "+url)
 
 	return url
 }

--- a/subtitles/subdb/subdb.go
+++ b/subtitles/subdb/subdb.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"io/ioutil"
 	"time"
+	logger "github.com/spf13/jwalterweatherman"
 )
 
 const (
@@ -37,9 +38,7 @@ func buildURL(hash string, language string) string {
 	v, _ := query.Values(opt)
 
 	url := baseURL + "?" + v.Encode()
-	if config.Verbose {
-		fmt.Println("SubdbURL is : " + url)
-	}
+	utils.VerbosePrintln(logger.INFO, "SubdbURL is : " + url)
 
 	return url
 }

--- a/subtitles/subdb/subdb.go
+++ b/subtitles/subdb/subdb.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/google/go-querystring/query"
 	"github.com/lafikl/fluent"
-	"github.com/vincentdaniel/subify/common/config"
-	"github.com/vincentdaniel/subify/common/utils"
+	"github.com/matcornic/subify/common/config"
+	"github.com/matcornic/subify/common/utils"
 	"github.com/spf13/viper"
 	"io/ioutil"
 	"time"
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	userAgent = "SubDB/1.0 (Subify/0.1; http://github.com/vincentdaniel/subify)"
+	userAgent = "SubDB/1.0 (Subify/0.1; http://github.com/matcornic/subify)"
 	devURL    = "http://sandbox.thesubdb.com/"
 	prodURL   = "http://api.thesubdb.com/"
 	defaultLanguage = "en"

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -1,14 +1,12 @@
 package subtitles
 
 import (
-	"fmt"
-	"github.com/matcornic/subify/common/config"
-	"github.com/matcornic/subify/common/utils"
-	"github.com/matcornic/subify/subtitles/subdb"
+	"github.com/vincentdaniel/subify/common/utils"
+	"github.com/vincentdaniel/subify/subtitles/subdb"
 	"github.com/spf13/viper"
 	"io/ioutil"
-	"os"
 	"path/filepath"
+	logger "github.com/spf13/jwalterweatherman"
 )
 
 // Download the subtitle from the video identified by its path
@@ -21,7 +19,7 @@ func Download(videoPath string) {
 	subtitlePath := buildSubtitleName(videoPath)
 	saveSubtitle(subtitle, subtitlePath)
 
-	fmt.Println("Subtitle (" + viper.GetString("language") + ") found and saved to " + subtitlePath)
+	logger.INFO.Println("Subtitle (", viper.GetString("language"), ") found and saved to ", subtitlePath)
 }
 
 func buildSubtitleName(pathVideo string) string {
@@ -33,9 +31,6 @@ func buildSubtitleName(pathVideo string) string {
 func saveSubtitle(content []byte, subtitlePath string) {
 	err := ioutil.WriteFile(subtitlePath, content, 0644)
 	if err != nil {
-		if config.Verbose {
-			fmt.Fprintln(os.Stderr, err)
-		}
-		utils.Exit("Can't save the file %v", subtitlePath)
+		utils.ExitPrintError(err, "Can't save the file %v", subtitlePath)
 	}
 }

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -1,12 +1,13 @@
 package subtitles
 
 import (
-	"github.com/matcornic/subify/common/utils"
-	"github.com/matcornic/subify/subtitles/subdb"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/matcornic/subify/common/utils"
+	"github.com/matcornic/subify/subtitles/subdb"
 	logger "github.com/spf13/jwalterweatherman"
+	"github.com/spf13/viper"
 )
 
 // Download the subtitle from the video identified by its path

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -1,8 +1,8 @@
 package subtitles
 
 import (
-	"github.com/vincentdaniel/subify/common/utils"
-	"github.com/vincentdaniel/subify/subtitles/subdb"
+	"github.com/matcornic/subify/common/utils"
+	"github.com/matcornic/subify/subtitles/subdb"
 	"github.com/spf13/viper"
 	"io/ioutil"
 	"path/filepath"


### PR DESCRIPTION
#### What's this PR do?

Usage of a logging framework instead of direct calls to the fmt api (fmt.Println, ...)
#### Where should the reviewer start?
- logging.go: defines the logging config
- utils.go: modifications were made to factor exit code and verbose logging
- have a look at https://github.com/spf13/jwalterweatherman which is the logging framework used (this could easily be replaced later by another framework if needed)
#### What are the relevant tickets?

[#1](https://github.com/matcornic/subify/issues/1)
