### PR TITLE
Multiple file download

### DIFF
--- a/cmd/dl.go
+++ b/cmd/dl.go
@@ -100,9 +100,9 @@ func getTargetsFromDirectory(path string) []string {
 
 // isVideoFilename checks if a filename ends in a video extension
 func isVideoFilename(fname string) bool {
-	ext := filepath.Ext(fname)
+	ext := strings.ToLower(filepath.Ext(fname))
 	for _, v := range viper.GetStringSlice("download.extensions") {
-		if "."+v == ext {
+		if "."+strings.ToLower(v) == ext {
 			return true
 		}
 	}

--- a/cmd/dl.go
+++ b/cmd/dl.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/matcornic/subify/common/utils"
@@ -23,36 +26,100 @@ var dlCmd = &cobra.Command{
 	Long: `Download the subtitles for your video (movie or TV Shows)
 Give the path of your video as first parameter and let's go !`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 1 {
-			utils.Exit("Video file needed. See usage : 'subify help' or 'subify dl --help'")
+		if len(args) <= 0 {
+			utils.Exit("At least one video file needed. See usage : 'subify help' or 'subify dl --help'")
 		}
-		videoPath := args[0]
-		utils.VerbosePrintln(logger.INFO, "Given video file is "+videoPath)
 
-		apis := strings.Split(viper.GetString("download.apis"), ",")
-		languages := strings.Split(viper.GetString("download.languages"), ",")
-		err := subtitles.Download(videoPath, apis, languages, notify)
-		if err != nil {
-			utils.ExitPrintError(err, "Sadly, we could not download any subtitle for you. Try another time or contribute to the apis. See 'subify upload -h'")
-		}
-		if openVideo {
-			err := open.Run(videoPath)
+		targets := enumerateTargets(args)
+
+		for _, videoPath := range targets {
+			utils.VerbosePrintln(logger.INFO, "Given video file is "+videoPath)
+
+			apis := strings.Split(viper.GetString("download.apis"), ",")
+			languages := strings.Split(viper.GetString("download.languages"), ",")
+			err := subtitles.Download(videoPath, apis, languages, notify)
 			if err != nil {
-				utils.ExitPrintError(err, "Sadly, we could not open video: %s", videoPath)
+				utils.VerbosePrintln(logger.ERROR, "Sadly, we could not download any subtitle for \""+videoPath+"\". Try another time or contribute to the apis. See 'subify upload -h'")
+			}
+			if openVideo {
+				err := open.Run(videoPath)
+				if err != nil {
+					utils.ExitPrintError(err, "Sadly, we could not open video: %s", videoPath)
+				}
 			}
 		}
 	},
 }
 
+// enumerateTargets checks if there are any directories in the argument list:
+// if there are, it recursively adds subfiles that are videos
+func enumerateTargets(paths []string) []string {
+	res := []string{}
+
+	for _, path := range paths {
+		// Check if the file is a directory. If it is, use all videos inside it as targets
+		stat, err := os.Stat(path)
+		if err != nil {
+			utils.VerbosePrintln(logger.ERROR, err.Error())
+			continue
+		}
+
+		if stat.IsDir() {
+			res = append(res, getTargetsFromDirectory(path)...)
+		} else {
+			res = append(res, path)
+		}
+	}
+
+	return res
+}
+
+// getTargetsFromDirectory receives a directory path and recursively returns
+// all it's video files and subfiles
+func getTargetsFromDirectory(path string) []string {
+	res := []string{}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		utils.VerbosePrintln(logger.ERROR, err.Error())
+		return nil
+	}
+
+	for _, file := range files {
+		fullPath := filepath.Join(path, file.Name())
+
+		if !file.IsDir() && isVideoFilename(file.Name()) {
+			res = append(res, fullPath)
+		} else if file.IsDir() {
+			res = append(res, getTargetsFromDirectory(fullPath)...)
+		}
+	}
+
+	return res
+}
+
+// isVideoFilename checks if a filename ends in a video extension
+func isVideoFilename(fname string) bool {
+	ext := filepath.Ext(fname)
+	for _, v := range viper.GetStringSlice("download.extensions") {
+		if "."+v == ext {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	dlCmd.Flags().StringP("languages", "l", "en", "Languages of the subtitle separate by a comma (First to match is downloaded). Available languages at 'subify list languages'")
 	dlCmd.Flags().StringP("apis", "a", "SubDB,OpenSubtitles,Addic7ed", "Overwrite default searching APIs behavior, hence the subtitles are downloaded. Available APIs at 'subify list apis'")
+	dlCmd.Flags().StringSliceP("extensions", "e", []string{"wmv", "mov", "webm", "mkv", "avi", "mp4"}, "List of file extensions that should be considered videos.")
 	dlCmd.Flags().BoolVarP(&openVideo, "open", "o", false,
 		"Once the subtitle is downloaded, open the video with your default video player"+
 			` (OSX: "open", Windows: "start", Linux/Other: "xdg-open")`)
 	dlCmd.Flags().BoolVarP(&notify, "notify", "n", true, "Display desktop notification")
 	_ = viper.BindPFlag("download.languages", dlCmd.Flags().Lookup("languages"))
 	_ = viper.BindPFlag("download.apis", dlCmd.Flags().Lookup("apis"))
+	_ = viper.BindPFlag("download.extensions", dlCmd.Flags().Lookup("extensions"))
 
 	RootCmd.AddCommand(dlCmd)
 }

--- a/notif/notif_darwin.go
+++ b/notif/notif_darwin.go
@@ -9,13 +9,15 @@ import (
 const notificationGroup = "com.matcornic.subify"
 
 // SendSubtitleDownloadSuccess sends a notification when download went well
-func SendSubtitleDownloadSuccess(successAPI string) {
-	_ = Info("I found a subtitle for your video 😎", fmt.Sprintf("Thank you %s ❤️", successAPI))
+func SendSubtitleDownloadSuccess(successAPI, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Info("I found a subtitle for \""+bn+"\" 😎", fmt.Sprintf("Thank you %s ❤️", successAPI))
 }
 
 // SendSubtitleCouldNotBeDownloaded sends a notification when download went bad
-func SendSubtitleCouldNotBeDownloaded(noSucessAPIs string) {
-	_ = Error("‼️ I didn't found any subtitle 😭", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
+func SendSubtitleCouldNotBeDownloaded(noSucessAPIs, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Error("!! I didn't found any subtitle for \""+bn+"\" 😭", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
 }
 
 // Error send a notification error

--- a/notif/notif_freebsd.go
+++ b/notif/notif_freebsd.go
@@ -6,13 +6,15 @@ import (
 )
 
 // SendSubtitleDownloadSuccess sends a notification when download went well
-func SendSubtitleDownloadSuccess(successAPI string) {
-	_ = Info("I found a subtitle for your video :)", fmt.Sprintf("Thank you %s <3", successAPI))
+func SendSubtitleDownloadSuccess(successAPI, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Info("I found a subtitle for \""+bn+"\" :)", fmt.Sprintf("Thank you %s <3", successAPI))
 }
 
 // SendSubtitleCouldNotBeDownloaded sends a notification when download went bad
-func SendSubtitleCouldNotBeDownloaded(noSucessAPIs string) {
-	_ = Error("!! I didn't found any subtitle :'(", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
+func SendSubtitleCouldNotBeDownloaded(noSucessAPIs, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Error("!! I didn't found any subtitle for \""+bn+"\" :'(", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
 }
 
 func sendMessage(title, message string) error {

--- a/notif/notif_linux.go
+++ b/notif/notif_linux.go
@@ -3,16 +3,19 @@ package notif
 import (
 	"fmt"
 	"os/exec"
+	"path"
 )
 
 // SendSubtitleDownloadSuccess sends a notification when download went well
-func SendSubtitleDownloadSuccess(successAPI string) {
-	_ = Info("I found a subtitle for your video :)", fmt.Sprintf("Thank you %s <3", successAPI))
+func SendSubtitleDownloadSuccess(successAPI, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Info("I found a subtitle for \""+bn+"\" :)", fmt.Sprintf("Thank you %s <3", successAPI))
 }
 
 // SendSubtitleCouldNotBeDownloaded sends a notification when download went bad
-func SendSubtitleCouldNotBeDownloaded(noSucessAPIs string) {
-	_ = Error("!! I didn't found any subtitle :'(", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
+func SendSubtitleCouldNotBeDownloaded(noSucessAPIs, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Error("!! I didn't found any subtitle for \""+bn+"\" :'(", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
 }
 
 func sendMessage(title, message string) error {

--- a/notif/notif_netbsd.go
+++ b/notif/notif_netbsd.go
@@ -3,12 +3,12 @@ package notif
 // Notifications are disabled for netbsd but we want a netbsd executable though
 
 // SendSubtitleDownloadSuccess sends a notification when download went well
-func SendSubtitleDownloadSuccess(successAPI string) {
+func SendSubtitleDownloadSuccess(successAPI, videoPath string) {
 	return
 }
 
 // SendSubtitleCouldNotBeDownloaded sends a notification when download went bad
-func SendSubtitleCouldNotBeDownloaded(noSucessAPIs string) {
+func SendSubtitleCouldNotBeDownloaded(noSucessAPIs, videoPath string) {
 	return
 }
 

--- a/notif/notif_openbsd.go
+++ b/notif/notif_openbsd.go
@@ -3,12 +3,12 @@ package notif
 // Notifications are disabled for netbsd but we want a netbsd executable though
 
 // SendSubtitleDownloadSuccess sends a notification when download went well
-func SendSubtitleDownloadSuccess(successAPI string) {
+func SendSubtitleDownloadSuccess(successAPI, videoPath string) {
 	return
 }
 
 // SendSubtitleCouldNotBeDownloaded sends a notification when download went bad
-func SendSubtitleCouldNotBeDownloaded(noSucessAPIs string) {
+func SendSubtitleCouldNotBeDownloaded(noSucessAPIs, videoPath string) {
 	return
 }
 

--- a/notif/notif_windows.go
+++ b/notif/notif_windows.go
@@ -7,13 +7,15 @@ import (
 )
 
 // SendSubtitleDownloadSuccess sends a notification when download went well
-func SendSubtitleDownloadSuccess(successAPI string) {
-	_ = Info("I found a subtitle for your video :)", fmt.Sprintf("Thank you %s <3", successAPI))
+func SendSubtitleDownloadSuccess(successAPI, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Info("I found a subtitle for \""+bn+"\" :)", fmt.Sprintf("Thank you %s <3", successAPI))
 }
 
 // SendSubtitleCouldNotBeDownloaded sends a notification when download went bad
-func SendSubtitleCouldNotBeDownloaded(noSucessAPIs string) {
-	_ = Error("I'm sorry, I didn't found any subtitle :'(", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
+func SendSubtitleCouldNotBeDownloaded(noSucessAPIs, videoPath string) {
+	bn := path.Base(videoPath)
+	_ = Error("!! I didn't found any subtitle for \""+bn+"\" :'(", fmt.Sprintf("No match for your video in : %s. Try later !", noSucessAPIs))
 }
 
 func sendMessage(title, message string) error {

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -62,7 +62,7 @@ func (c Clients) Print() {
 	table.Render() // Send output
 }
 
-//String prints a nice representation of clients
+// String prints a nice representation of clients
 func (c Clients) String() (s string) {
 	for i, v := range c {
 		s = s + v.GetName()
@@ -108,7 +108,7 @@ browselang:
 			subtitlePath, err = api.Download(videoPath, lang)
 			if err == nil {
 				if notify {
-					notif.SendSubtitleDownloadSuccess(api.GetName())
+					notif.SendSubtitleDownloadSuccess(api.GetName(), videoPath)
 				}
 				logger.INFO.Println(lang.Description, "subtitle found and saved to ", subtitlePath)
 				break browselang
@@ -129,7 +129,7 @@ browselang:
 
 	if err != nil {
 		if notify {
-			notif.SendSubtitleCouldNotBeDownloaded(a.String())
+			notif.SendSubtitleCouldNotBeDownloaded(a.String(), videoPath)
 		}
 		return fmt.Errorf("No %v subtitle found, even after searching in all APIs (%v)", strings.Join(l.GetDescriptions(), ", nor "), a.String())
 	}


### PR DESCRIPTION
This commit implements multiple file downloading:
`$ subify dl MyVideo1.mp4 MyVideo2.mkv` downloads subtitles for these two files
`$ subify dl ~/Videos/Shows/TheMuppets` recursively downloads subtitles for all video files found inside the *TheMuppets* directory.
`$ subify dl ~/Videos/Shows/TheMuppets -e mp4,mkv` recursively downloads subtitles for all video files found inside the *TheMuppets* directory, but only those that end in `.mp4` or `.mkv` (default value is `wmv, mov, webm, mkv, avi, mp4`).